### PR TITLE
Fix missing arguments in print-like function

### DIFF
--- a/glog.go
+++ b/glog.go
@@ -50,7 +50,7 @@ func (v Verbose) Info(args ...interface{}) {
 
 // Infoln is a shim
 func (v Verbose) Infoln(args ...interface{}) {
-	s := fmt.Sprint(args)
+	s := fmt.Sprint(args...)
 	zap.S().Debug(s, "\n")
 }
 
@@ -71,7 +71,7 @@ func InfoDepth(depth int, args ...interface{}) {
 
 // Infoln is a shim
 func Infoln(args ...interface{}) {
-	s := fmt.Sprint(args)
+	s := fmt.Sprint(args...)
 	zap.S().Info(s, "\n")
 }
 
@@ -92,7 +92,7 @@ func WarningDepth(depth int, args ...interface{}) {
 
 // Warningln is a shim
 func Warningln(args ...interface{}) {
-	s := fmt.Sprint(args)
+	s := fmt.Sprint(args...)
 	zap.S().Warn(s, "\n")
 }
 
@@ -113,7 +113,7 @@ func ErrorDepth(depth int, args ...interface{}) {
 
 // Errorln is a shim
 func Errorln(args ...interface{}) {
-	s := fmt.Sprint(args)
+	s := fmt.Sprint(args...)
 	zap.S().Error(s, "\n")
 }
 
@@ -136,7 +136,7 @@ func FatalDepth(depth int, args ...interface{}) {
 
 // Fatalln is a shim
 func Fatalln(args ...interface{}) {
-	s := fmt.Sprint(args)
+	s := fmt.Sprint(args...)
 	zap.S().Error(s, "\n")
 	os.Exit(255)
 }
@@ -161,7 +161,7 @@ func ExitDepth(depth int, args ...interface{}) {
 
 // Exitln is a shim
 func Exitln(args ...interface{}) {
-	s := fmt.Sprint(args)
+	s := fmt.Sprint(args...)
 	zap.S().Error(s, "\n")
 	os.Exit(1)
 }


### PR DESCRIPTION
Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>


Fix the following error on Go 1.15:

```
Testing    in: /builddir/build/BUILD/glog-d7cfb6fa2ccda15565f68f204d68907c80a5c977/_build/src
         PATH: /builddir/build/BUILD/glog-d7cfb6fa2ccda15565f68f204d68907c80a5c977/_build/bin:/builddir/.local/bin:/builddir/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin
       GOPATH: /builddir/build/BUILD/glog-d7cfb6fa2ccda15565f68f204d68907c80a5c977/_build:/usr/share/gocode
  GO111MODULE: off
      command: go test -buildmode pie -compiler gc -ldflags "-X github.com/istio/glog/version=0 -X github.com/istio/glog/version.commit=d7cfb6fa2ccda15565f68f204d68907c80a5c977 -extldflags '-Wl,-z,relro -Wl,--as-needed  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld '"
      testing: github.com/istio/glog
github.com/istio/glog
# github.com/istio/glog
./glog.go:53:7: missing ... in args forwarded to print-like function
./glog.go:74:7: missing ... in args forwarded to print-like function
./glog.go:95:7: missing ... in args forwarded to print-like function
./glog.go:116:7: missing ... in args forwarded to print-like function
./glog.go:139:7: missing ... in args forwarded to print-like function
./glog.go:164:7: missing ... in args forwarded to print-like function
FAIL	github.com/istio/glog [build failed]
```